### PR TITLE
Escape of URLs at sitemap.xml

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -9,7 +9,7 @@ sitemap:
   {% for post in site.posts %}
   {% unless post.published == false %}
   <url>
-    <loc>{{ site.url }}{{ post.url }}</loc>
+    <loc>{{ site.url }}{{ post.url | xml_escape }}</loc>
     {% if post.sitemap.lastmod %}
     <lastmod>{{ post.sitemap.lastmod | date: "%Y-%m-%d" }}</lastmod>
     {% elsif post.date %}
@@ -33,7 +33,7 @@ sitemap:
   {% for page in site.pages %}
   {% unless page.sitemap.exclude == "yes" %}
   <url>
-    <loc>{{ site.url }}{{ page.url | remove: "index.html" }}</loc>
+    <loc>{{ site.url }}{{ page.url | remove: "index.html" | xml_escape }}</loc>
     {% if page.sitemap.lastmod %}
     <lastmod>{{ page.sitemap.lastmod | date: "%Y-%m-%d" }}</lastmod>
     {% elsif page.date %}


### PR DESCRIPTION
Current version of sitemap.xml has no escaping. If you try to open https://techblog.badoo.com/sitemap.xml you will see a error:

> This page contains the following errors:
>
> error on line 1708 at column 57: xmlParseEntityRef: no name
> Below is a rendering of the page up to the first error.

The error line contains this:
> <loc>https://techblog.badoo.com/authors/erik-andre-&-rich-king/</loc>

This line is invalid due to absence of "&" escaping.
I have fixed it.